### PR TITLE
Simplify main menu and add layer selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
             <option value="satellite">ماهواره‌ای</option>
             <option value="osm">نقشه</option>
             <option value="light">روشن</option>
+            <option value="terrain">توپوگرافی</option>
           </select>
         </label>
         <label class="btn" style="padding:6px 8px;margin-inline-end:4px">


### PR DESCRIPTION
Simplify the main dashboard UI, add a map layer selector with persistence, and move cluttered actions to a quick menu.

The main dashboard was too cluttered, so the UI has been streamlined by introducing a compact layer selector (satellite, traffic, OSM, dark, light, terrain) and moving numerous action buttons into a "Quick Menu" modal. The selected base layer and traffic toggle state are now persisted in LocalStorage for improved user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-abb598c9-84a6-4c8b-a134-3f983d505602">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-abb598c9-84a6-4c8b-a134-3f983d505602">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

